### PR TITLE
- removed set_project_by_id and set_project_by_name to one method

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,8 +31,36 @@ def mock_testdroid_client(monkeypatch):
             'frameworkId': 99
         }
 
+    def get_projects_wrapper(object):
+        return {
+            'data': [
+                {
+                    'id': 1,
+                    'name': 'mock_project',
+                    'type': 'mock_type',
+                    'osType': 'mock_type',
+                    'frameworkId': 99
+                },
+                {
+                    'id': 99,
+                    'name': 'another_mock_project',
+                    'type': 'second_mock_type',
+                    'osType': 'second_mock_type',
+                    'frameworkId': 88
+                },
+                {
+                    'id': 10000,
+                    'name': 'yet_another_mock_project',
+                    'type': 'third_mock_type',
+                    'osType': 'third_mock_type',
+                    'frameworkId': 12345
+                },
+            ]
+        }
+
     monkeypatch.setattr(Testdroid, 'get_token', get_token_wrapper)
     monkeypatch.setattr(Testdroid, 'get_project', get_project_wrapper)
+    monkeypatch.setattr(Testdroid, 'get_projects', get_projects_wrapper)
 
     return init
 
@@ -41,8 +69,8 @@ def mock_testdroid_client(monkeypatch):
 def mock_bitbar_project(monkeypatch):
     def init(project_status, **kwargs):
         with patch.object(BitbarProject, '__init__') as project:
-            project.project_id = kwargs.get('project_id')
-            project.name = 'mock_project'
+            project.project_id = kwargs.get('id') or 1
+            project.name = kwargs.get('name') or 'mock_type'
             project.type = 'mock_type'
             project.framework_id = 99
             project.device_group_id = 1

--- a/tests/test_bitbar_project.py
+++ b/tests/test_bitbar_project.py
@@ -1,5 +1,7 @@
 from __future__ import print_function, absolute_import
 
+import string
+
 import pytest
 
 from mozbitbar.bitbar_project import BitbarProject
@@ -7,27 +9,83 @@ from mozbitbar import ProjectException
 
 
 @pytest.mark.parametrize('kwargs,expected', [
-        ({'project_id': 1}, 1),
-        ({'project_id': 999}, 999),
-        ({'project_id': 2**32}, 2**32),
-        ({'project_id': 0}, 0),
-        ({'project_id': -1}, -1),
-        ])
-def test_bitbar_project(kwargs, expected):
-    """Ensures BitbarProject sets project_id as expected.
+    ({'id': 1}, 1),
+    ({'id': 99}, 99),
+])
+def test_bb_project_existing_id(kwargs, expected):
+    """Ensures BitbarProject sets id as expected.
 
     Directly tests methods involved in:
         - initialization
-        - branching logic based on project_id or project_name
-        - setting of project by project_id
+        - setting of project by id
 
     Indirectly tests methods involved in:
-        - property setter for project_id
+        - property setter for id
 
-    Last call Testdroid.get_project is mocked.
+    Last call Testdroid.get_project is mocked to return a pseudo
+    project.
     """
     project = BitbarProject('existing', **kwargs)
     assert project.project_id == expected
+
+
+@pytest.mark.parametrize('kwargs', [
+    {'id': 100},
+    {'id': 2**32},
+    {'id': -1},
+])
+def test_bb_project_existing_invalid_id(kwargs):
+    """Ensures BitbarProject raises an exception on invalid
+    project ID.
+    """
+    with pytest.raises(ProjectException):
+        BitbarProject('existing', **kwargs)
+
+
+@pytest.mark.parametrize('kwargs,expected', [
+        ({'name': 'mock_project'}, 'mock_project')
+        ])
+def test_bb_project_existing_name(kwargs, expected):
+    """Ensures BitbarProject sets name as expected.
+
+    Directly tests methods involved in:
+        - initialization
+        - branching logic based on name or name
+        - setting of project by name
+
+    Indirectly tests methods involved in:
+        - property setter for name
+
+    Last call Testdroid.get_project is mocked to return a pseudo
+    project.
+    """
+    project = BitbarProject('existing', **kwargs)
+    assert project.project_name == expected
+
+
+@pytest.mark.parametrize('kwargs', [
+    {'name': string.lowercase},
+    {'name': 'NULL'},
+    {'name': 'None'},
+])
+def test_bb_project_existing_invalid_name(kwargs):
+    with pytest.raises(ProjectException):
+        BitbarProject('existing', **kwargs)
+
+
+@pytest.mark.parametrize('kwargs,expected', [
+    ({'id': 1, 'name': 'mock_project'}, [1, 'mock_project']),
+    ({'id': 10000, 'name': 'mock_project'},
+     [10000, 'yet_another_mock_project']),
+])
+def test_bb_project_existing_id_and_name(kwargs, expected):
+    """Ensures BitbarProject can accept scenario with both
+    id and name provided. Verifies that existing project selection
+    prioritizes project id over name.
+    """
+    project = BitbarProject('existing', **kwargs)
+    assert project.project_id == expected[0]
+    assert project.project_name == expected[1]
 
 
 @pytest.mark.parametrize('project_status', ['present', 'exist', 'create'])


### PR DESCRIPTION
- expanded use_existing_project to accept both name and id to set projects