### PR TITLE
- removed overloading of Testdroid's __init__ method from conftest - …

### DIFF
--- a/mozbitbar/configuration.py
+++ b/mozbitbar/configuration.py
@@ -27,7 +27,7 @@ class Configuration(object):
             MozbitbarCredentialException: If minimum required credentials
                 were not set, or supplied credentials were invalid.
         """
-        if kwargs and 'TESTDROID_URL' in kwargs.keys():
+        if kwargs and any(['TESTDROID' in key for key in kwargs.keys()]):
             self.user_name = kwargs.get('TESTDROID_USERNAME')
             self.user_password = kwargs.get('TESTDROID_PASSWORD')
             self.api_key = kwargs.get('TESTDROID_APIKEY')

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,8 @@ PACKAGE_VERSION = '.'.join([
     str(item) for item in [MAJOR_VERSION, MINOR_VERSION, REVISION]
 ])
 DESCRIPTION = '''Tool to interact with Bitbar REST API.'''
-with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'README.md')) as f:
+with open(os.path.join(os.path.dirname(
+        os.path.abspath(__file__)), 'README.md')) as f:
     README = f.read()
 
 DEPENDENCIES = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,10 +8,7 @@ import random
 
 import pytest
 
-
 from testdroid import Testdroid
-
-from mock import patch
 
 
 def mock_projects_list():
@@ -77,13 +74,6 @@ def mock_project_config(project_status=None, project_framework_id=None,
 
 @pytest.fixture(autouse=True)
 def mock_testdroid_client(monkeypatch):
-    def init(object, **kwargs):
-        with patch.object(Testdroid, '__init__') as client:
-            client.apikey = 'test_apikey'
-            client.username = 'test_username'
-            client.password = 'test_password'
-            client.cloud_url = 'https://testingurl.com'
-            client.download_buffer_size = 65536
 
     # Project related mocks #
 
@@ -154,6 +144,7 @@ def mock_testdroid_client(monkeypatch):
     # Additional mocks #
 
     def get_me_wrapper(object):
+        print(object.api_key)
         return {
             'id': 1,
             'accountId': 2,
@@ -165,7 +156,6 @@ def mock_testdroid_client(monkeypatch):
 
     # Monkeypatch #
 
-    monkeypatch.setattr(Testdroid, '__init__', init)
     monkeypatch.setattr(Testdroid, 'create_project', create_project_wrapper)
     monkeypatch.setattr(Testdroid, 'get_frameworks',
                         get_frameworks_wrapper)
@@ -181,5 +171,3 @@ def mock_testdroid_client(monkeypatch):
     monkeypatch.setattr(Testdroid, 'set_project_framework',
                         set_project_framework_wrapper)
     monkeypatch.setattr(Testdroid, 'upload_file', upload_file_wrapper)
-
-    return init

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -144,7 +144,6 @@ def mock_testdroid_client(monkeypatch):
     # Additional mocks #
 
     def get_me_wrapper(object):
-        print(object.api_key)
         return {
             'id': 1,
             'accountId': 2,

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -6,10 +6,7 @@ from __future__ import print_function, absolute_import
 
 import pytest
 
-<<<<<<< HEAD
 from mozbitbar import MozbitbarCredentialException
-=======
->>>>>>> ef5a583ab5966f99c1f56a09b5e9fea8a8490a68
 from mozbitbar.configuration import Configuration
 
 
@@ -22,7 +19,6 @@ from mozbitbar.configuration import Configuration
             'TESTDROID_URL': 'https://www.mock_test.com',
         },
         {
-<<<<<<< HEAD
             'user_name': 'MOCK_TEST',
             'user_password': 'MOCK_TEST',
             'api_key': 'MOCK_TEST',
@@ -49,7 +45,7 @@ from mozbitbar.configuration import Configuration
         MozbitbarCredentialException
     )
 ])
-def test_configuration(kwargs,expected):
+def test_configuration_from_kwargs(kwargs, expected):
     """Ensures the Configuration object can be instantiated with appropriate
     values provided to the constructor.
     """
@@ -62,15 +58,74 @@ def test_configuration(kwargs,expected):
         for attribute, value in expected.iteritems():
             assert hasattr(config, attribute)
             assert getattr(config, attribute) == value
-=======
-            None
+
+
+@pytest.mark.parametrize('kwargs,expected', [
+    (
+        {
+            'TESTDROID_USERNAME': 'MOCK_ENVIRONMENT_VALUE_TEST',
+            'TESTDROID_PASSWORD': 'MOCK_ENVIRONMENT_VALUE_TEST',
+            'TESTDROID_APIKEY': 'MOCK_ENVIRONMENT_VALUE_TEST',
+            'TESTDROID_URL': 'https://www.mock_test_env_var.com',
+        },
+        {
+            'user_name': 'MOCK_ENVIRONMENT_VALUE_TEST',
+            'user_password': 'MOCK_ENVIRONMENT_VALUE_TEST',
+            'api_key': 'MOCK_ENVIRONMENT_VALUE_TEST',
+            'url': 'https://www.mock_test_env_var.com',
         }
+    ),
+    (
+        {
+            'TESTDROID_USERNAME': 'MOCK_ENVIRONMENT_VALUE_TEST',
+            'TESTDROID_PASSWORD': 'MOCK_ENVIRONMENT_VALUE_TEST',
+            'TESTDROID_URL': 'https://www.mock_test_env_var.com',
+        },
+        {
+            'user_name': 'MOCK_ENVIRONMENT_VALUE_TEST',
+            'user_password': 'MOCK_ENVIRONMENT_VALUE_TEST',
+            'api_key': None,
+            'url': 'https://www.mock_test_env_var.com',
+        }
+    ),
+    (
+        {
+            'TESTDROID_APIKEY': 'MOCK_ENVIRONMENT_API_KEY',
+            'TESTDROID_URL': 'https://www.mock_test_env_var.com',
+        },
+        {
+            'api_key': 'MOCK_ENVIRONMENT_API_KEY',
+            'url': 'https://www.mock_test_env_var.com',
+        }
+    ),
+    (
+        {
+            'TESTDROID_URL': 'https://www.mock_test_env_var.com',
+        },
+        MozbitbarCredentialException
     )
 ])
-def test_configuration(kwargs, expected):
+def test_configuration_from_env_var(kwargs, expected, monkeypatch):
+    """Ensures the Configuration object can be instantiated using
+    key values set from environment variables.
     """
-    """
-    config = Configuration(**kwargs)
-    assert config.client is not None
-    assert config.url is kwargs.get('TESTDROID_URL')
->>>>>>> ef5a583ab5966f99c1f56a09b5e9fea8a8490a68
+    # dynamically patch the environment variable under test.
+    # first delete the environment variables.
+    monkeypatch.delenv('TESTDROID_USERNAME')
+    monkeypatch.delenv('TESTDROID_PASSWORD')
+    monkeypatch.delenv('TESTDROID_APIKEY')
+    monkeypatch.delenv('TESTDROID_URL')
+
+    # then set only the variables that were provided by test data.
+    for key, attribute in kwargs.iteritems():
+        monkeypatch.setenv(key, attribute)
+
+    if expected is MozbitbarCredentialException:
+        with pytest.raises(MozbitbarCredentialException):
+            config = Configuration()
+    else:
+        config = Configuration()
+        assert config.client is not None
+        for attribute, value in expected.iteritems():
+            assert hasattr(config, attribute)
+            assert getattr(config, attribute) == value

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1,0 +1,30 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from __future__ import print_function, absolute_import
+
+import pytest
+
+from mozbitbar.configuration import Configuration
+
+
+@pytest.mark.parametrize('kwargs,expected', [
+    (
+        {
+            'TESTDROID_USERNAME': 'MOCK_TEST',
+            'TESTDROID_PASSWORD': 'MOCK_TEST',
+            'TESTDROID_APIKEY': 'MOCK_TEST',
+            'TESTDROID_URL': 'https://www.mock_test.com',
+        },
+        {
+            None
+        }
+    )
+])
+def test_configuration(kwargs, expected):
+    """
+    """
+    config = Configuration(**kwargs)
+    assert config.client is not None
+    assert config.url is kwargs.get('TESTDROID_URL')

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -6,6 +6,7 @@ from __future__ import print_function, absolute_import
 
 import pytest
 
+from mozbitbar import MozbitbarCredentialException
 from mozbitbar.configuration import Configuration
 
 
@@ -18,13 +19,42 @@ from mozbitbar.configuration import Configuration
             'TESTDROID_URL': 'https://www.mock_test.com',
         },
         {
-            None
+            'user_name': 'MOCK_TEST',
+            'user_password': 'MOCK_TEST',
+            'api_key': 'MOCK_TEST',
+            'url': 'https://www.mock_test.com',
         }
+    ),
+    (
+        {
+            'TESTDROID_USERNAME': 'MOCK_TEST',
+            'TESTDROID_PASSWORD': 'MOCK_TEST',
+            'TESTDROID_URL': 'https://www.mock_test.com'
+        },
+        {
+            'user_name': 'MOCK_TEST',
+            'user_password': 'MOCK_TEST',
+            'api_key': None,
+            'url': 'https://www.mock_test.com',
+        }
+    ),
+    (
+        {
+            'TESTDROID_USERNAME': 'MOCK_TEST'
+        },
+        MozbitbarCredentialException
     )
 ])
-def test_configuration(kwargs, expected):
+def test_configuration(kwargs,expected):
+    """Ensures the Configuration object can be instantiated with appropriate
+    values provided to the constructor.
     """
-    """
-    config = Configuration(**kwargs)
-    assert config.client is not None
-    assert config.url is kwargs.get('TESTDROID_URL')
+    if expected is MozbitbarCredentialException:
+        with pytest.raises(MozbitbarCredentialException):
+            config = Configuration(**kwargs)
+    else:
+        config = Configuration(**kwargs)
+        assert config.client is not None
+        for attribute, value in expected.iteritems():
+            assert hasattr(config, attribute)
+            assert getattr(config, attribute) == value


### PR DESCRIPTION
…turns out it is not necesary to mock the creation of Testdroid client, just its methods

- added test for configuration, still a stub
- flake8 fixes